### PR TITLE
Fixed ansible.utils.ipaddr('host/prefix') function if size of subnet is 1

### DIFF
--- a/plugins/plugin_utils/base/ipaddr_utils.py
+++ b/plugins/plugin_utils/base/ipaddr_utils.py
@@ -100,7 +100,7 @@ def _ip_query(v):
 
 
 def _address_prefix_query(v):
-    if v.size > 2 and v.ip in (v.network, v.broadcast):
+    if v.ip in (v.network, v.broadcast):
         return False
     return str(v.ip) + "/" + str(v.prefixlen)
 


### PR DESCRIPTION

If non CIDR IP is given to  ansible.utils.ipaddr('host/prefix') function is not returning False value. 
e.g
```
 "192.168.0.21" | ansible.utils.ipaddr('host/prefix')
```
Ideally above code should return False value.  Hence corrected the behavior.